### PR TITLE
Require custom text field for location prescription information

### DIFF
--- a/assets/json/acf-json/group_uamswp_locations.json
+++ b/assets/json/acf-json/group_uamswp_locations.json
@@ -602,7 +602,7 @@
             "type": "wysiwyg",
             "label": "Custom Prescription Refills Information",
             "instructions": "",
-            "required": 0,
+            "required": 1,
             "conditional_logic": [
                 [
                     {


### PR DESCRIPTION
It's only displayed if the custom text option is selected.