### PR TITLE
Block for Locations & Providers

### DIFF
--- a/includes/class.fad-acf-blocks.php
+++ b/includes/class.fad-acf-blocks.php
@@ -121,7 +121,7 @@ if( function_exists('acf_add_local_field_group') ):
                 'name' => 'block_fad_locations_filter_type',
                 'type' => 'taxonomy',
                 'instructions' => '',
-                'required' => 1,
+                'required' => 0,
                 'conditional_logic' => 0,
                 'wrapper' => array(
                     'width' => '',


### PR DESCRIPTION
Marked location type input as not required. We include the note above this that says "You must fill in at least one filter. Otherwise the block will not be rendered." So really, no one input is required. Just any input, really.