### PR TITLE
Hot fix - AOE's TRL function global $post var

### DIFF
--- a/templates/single-expertise.php
+++ b/templates/single-expertise.php
@@ -513,6 +513,7 @@ function uamswp_expertise_podcast() {
     }
 }
 function uamswp_expertise_resource() {
+    global $post;
     global $page_title;
     global $show_related_resource_section;
     global $resources;


### PR DESCRIPTION
Forgot to pull the $post var into the function when I switched how the $resource_more_value value was defined. This adds it.