### PR TITLE
Auto-derive the Provider Spotlight title, slug, intro, and ontology from the featured provider

### DIFF
--- a/assets/json/acf-json/group_uamswp_clinical_resources.json
+++ b/assets/json/acf-json/group_uamswp_clinical_resources.json
@@ -841,7 +841,15 @@
 			"type": "tab",
 			"instructions": "",
 			"required": 0,
-			"conditional_logic": 0,
+			"conditional_logic": [
+				[
+					{
+						"field": "field_clinical_resource_type",
+						"operator": "!=",
+						"value": "provider_spotlight"
+					}
+				]
+			],
 			"wrapper": {
 				"width": "",
 				"class": "",
@@ -894,7 +902,15 @@
 			"type": "tab",
 			"instructions": "",
 			"required": 0,
-			"conditional_logic": 0,
+			"conditional_logic": [
+				[
+					{
+						"field": "field_clinical_resource_type",
+						"operator": "!=",
+						"value": "provider_spotlight"
+					}
+				]
+			],
 			"wrapper": {
 				"width": "",
 				"class": "",
@@ -910,7 +926,15 @@
 			"type": "relationship",
 			"instructions": "",
 			"required": 0,
-			"conditional_logic": 0,
+			"conditional_logic": [
+				[
+					{
+						"field": "field_clinical_resource_type",
+						"operator": "!=",
+						"value": "provider_spotlight"
+					}
+				]
+			],
 			"wrapper": {
 				"width": "",
 				"class": "",
@@ -939,7 +963,15 @@
 			"type": "tab",
 			"instructions": "",
 			"required": 0,
-			"conditional_logic": 0,
+			"conditional_logic": [
+				[
+					{
+						"field": "field_clinical_resource_type",
+						"operator": "!=",
+						"value": "provider_spotlight"
+					}
+				]
+			],
 			"wrapper": {
 				"width": "",
 				"class": "",
@@ -955,7 +987,15 @@
 			"type": "relationship",
 			"instructions": "",
 			"required": 0,
-			"conditional_logic": 0,
+			"conditional_logic": [
+				[
+					{
+						"field": "field_clinical_resource_type",
+						"operator": "!=",
+						"value": "provider_spotlight"
+					}
+				]
+			],
 			"wrapper": {
 				"width": "",
 				"class": "",
@@ -984,7 +1024,15 @@
 			"type": "tab",
 			"instructions": "",
 			"required": 0,
-			"conditional_logic": 0,
+			"conditional_logic": [
+				[
+					{
+						"field": "field_clinical_resource_type",
+						"operator": "!=",
+						"value": "provider_spotlight"
+					}
+				]
+			],
 			"wrapper": {
 				"width": "",
 				"class": "",
@@ -1000,7 +1048,15 @@
 			"type": "relationship",
 			"instructions": "",
 			"required": 0,
-			"conditional_logic": 0,
+			"conditional_logic": [
+				[
+					{
+						"field": "field_clinical_resource_type",
+						"operator": "!=",
+						"value": "provider_spotlight"
+					}
+				]
+			],
 			"wrapper": {
 				"width": "",
 				"class": "",
@@ -1029,7 +1085,15 @@
 			"type": "relationship",
 			"instructions": "",
 			"required": 0,
-			"conditional_logic": 0,
+			"conditional_logic": [
+				[
+					{
+						"field": "field_clinical_resource_type",
+						"operator": "!=",
+						"value": "provider_spotlight"
+					}
+				]
+			],
 			"wrapper": {
 				"width": "",
 				"class": "",

--- a/assets/json/acf-json/group_uamswp_clinical_resources.json
+++ b/assets/json/acf-json/group_uamswp_clinical_resources.json
@@ -44,7 +44,15 @@
 			"type": "textarea",
 			"instructions": "This will be the description included for this page when it appears in search results and in lists on our site.</p><p class='description' style='margin-top: 0.5em;'>Write a short description that generally informs and interests users with a short, relevant summary of what this page is about. Think of it like a pitch that convinces the user that this page is exactly what they're looking for.</p><p class='description' style='margin-top: 0.5em;'>The text will be limited to 160 characters. The preferred length is at least 110 characters.</p><p class='description' style='margin-top: 0.5em;'>Required for every resource type except Provider Spotlight, which generates a description automatically when this is left blank.",
 			"required": 0,
-			"conditional_logic": 0,
+			"conditional_logic": [
+				[
+					{
+						"field": "field_clinical_resource_type",
+						"operator": "!=",
+						"value": "provider_spotlight"
+					}
+				]
+			],
 			"wrapper": {
 				"width": "",
 				"class": "",
@@ -691,33 +699,6 @@
 			"acfe_validate": "",
 			"acfe_update": "",
 			"ui": 1
-		},
-		{
-			"key": "field_clinical_resource_spotlight_intro",
-			"label": "Introduction",
-			"name": "clinical_resource_spotlight_intro",
-			"type": "wysiwyg",
-			"instructions": "This will precede the provider's photo and the questions and answers.</p><p class='description' style='margin-top: 0.5em;'>Leave this blank to use an introduction generated automatically from the provider's name and clinical title.",
-			"required": 0,
-			"conditional_logic": [
-				[
-					{
-						"field": "field_clinical_resource_type",
-						"operator": "==",
-						"value": "provider_spotlight"
-					}
-				]
-			],
-			"wrapper": {
-				"width": "",
-				"class": "",
-				"id": ""
-			},
-			"default_value": "",
-			"tabs": "all",
-			"toolbar": "basic",
-			"media_upload": 0,
-			"delay": 1
 		},
 		{
 			"key": "field_clinical_resource_spotlight_qa",

--- a/includes/class.fad-acf-functions.php
+++ b/includes/class.fad-acf-functions.php
@@ -2301,6 +2301,121 @@
 
 		}
 
+	// Keep a spotlight's title and slug in sync with its featured provider
+	//
+	// The title is derived so it never drifts from the provider profile and
+	// never collides with it in search or SEO:
+	//
+	//  - Title: "Get to Know {full name}" (e.g. "Get to Know W. Ryan Wood,
+	//    O.D."), refreshed on every save so a provider rename flows through.
+	//  - Slug: built from the prefix- and degree-free name ("W. Ryan Wood" ->
+	//    get-to-know-w-ryan-wood) and then frozen once the resource is
+	//    published, since changing a live URL breaks inbound links. While the
+	//    resource is still a draft the slug tracks the provider.
+	//
+	// Runs at priority 20, after ACF writes the submitted values at 10, so
+	// get_field() returns the values saved in this same request.
+
+		add_action( 'acf/save_post', 'uamswp_spotlight_sync_title', 20 );
+
+		function uamswp_spotlight_sync_title( $post_id ) {
+
+			// Only clinical resources that are (still) a spotlight with a
+			// featured provider
+
+				if (
+					!is_numeric( $post_id )
+					||
+					'clinical-resource' !== get_post_type( $post_id )
+					||
+					'provider_spotlight' !== uamswp_spotlight_stored_type( $post_id )
+				) {
+
+					return;
+
+				}
+
+				$provider_id = (int) get_field( 'clinical_resource_spotlight_provider', $post_id );
+
+				if ( !$provider_id ) {
+
+					return;
+
+				}
+
+			$names = uamswp_provider_names( $provider_id );
+
+			// The name variants can carry &nbsp; (for a generational suffix), so
+			// normalize it to a regular space for these plain-text fields.
+
+				$full = trim( str_replace( '&nbsp;', ' ', $names['full'] ) );
+
+				if ( '' === $full ) {
+
+					return;
+
+				}
+
+			$post = get_post( $post_id );
+
+			if ( !$post ) {
+
+				return;
+
+			}
+
+			$update = array();
+
+			// Title: always track the provider
+
+				$new_title = 'Get to Know ' . $full;
+
+				if ( $post->post_title !== $new_title ) {
+
+					$update['post_title'] = $new_title;
+
+				}
+
+			// Slug: track the provider while drafting, then freeze at publish
+
+				$published = in_array( $post->post_status, array( 'publish', 'future', 'private' ), true );
+
+				if ( !$published ) {
+
+					$slug_name = trim( str_replace( '&nbsp;', ' ', $names['medium_no_prefix'] ) );
+
+					if ( '' !== $slug_name ) {
+
+						$new_slug = sanitize_title( 'Get to Know ' . $slug_name );
+
+						if ( $new_slug && $post->post_name !== $new_slug ) {
+
+							$update['post_name'] = $new_slug;
+
+						}
+
+					}
+
+				}
+
+			if ( !$update ) {
+
+				return;
+
+			}
+
+			$update['ID'] = $post_id;
+
+			// Unhook around the nested save so this does not re-enter
+
+				remove_action( 'acf/save_post', 'uamswp_spotlight_sync_title', 20 );
+
+				wp_update_post( $update );
+
+				add_action( 'acf/save_post', 'uamswp_spotlight_sync_title', 20 );
+
+		}
+
 	// Resolve the 16:9 image a spotlight uses for social sharing and cards
 	//
 	// Precedence: the override image, then the provider's wide portrait, then

--- a/includes/class.fad-acf-functions.php
+++ b/includes/class.fad-acf-functions.php
@@ -2593,6 +2593,7 @@
 			foreach ( $spotlights as $spotlight_id ) {
 
 				uamswp_spotlight_assert_link( $spotlight_id, (int) $post_id );
+				uamswp_spotlight_sync_ontology( $spotlight_id, (int) $post_id );
 
 			}
 
@@ -2681,11 +2682,13 @@
 			if ( 'publish' === $new_status ) {
 
 				uamswp_spotlight_assert_link( (int) $post->ID, $provider_id );
+				uamswp_spotlight_sync_ontology( (int) $post->ID, $provider_id );
 
 			} elseif ( 'publish' === $old_status ) {
 
 				// Unpublished, trashed, or otherwise taken out of publication
 				uamswp_spotlight_release_link( (int) $post->ID, $provider_id );
+				uamswp_spotlight_sync_ontology( (int) $post->ID, 0 );
 
 			}
 
@@ -2728,5 +2731,257 @@
 			}
 
 			uamswp_spotlight_release_link( (int) $post_id, $provider_id );
+			uamswp_spotlight_sync_ontology( (int) $post_id, 0 );
+
+		}
+
+	// --- Ontology mirroring: a spotlight inherits its provider's ontology ---
+	//
+	// Locations, Areas of Expertise, Conditions, and Treatments are copied from
+	// the featured provider onto the spotlight and kept in step continuously, so
+	// editors never curate them by hand (the fields and their tabs are hidden for
+	// spotlights). Each clinical-resource field is bidirectional with its ontology
+	// post, so the same machinery behind the provider mirror also carries the
+	// spotlight into each location/expertise/condition/treatment post's own
+	// Related Clinical Resources. The set is an exact copy of the provider's
+	// (overwrite, not union) -- unlike clinical_resource_providers, which unions
+	// the featured provider with the editor's own picks.
+
+		// clinical-resource field key => the field name, the provider source
+		// field, and the ontology post's reverse-relationship field key.
+		function uamswp_spotlight_ontology_map() {
+
+			return array(
+				'field_clinical_resource_locations'  => array( 'name' => 'clinical_resource_locations',  'provider' => 'physician_locations',      'reverse' => 'field_location_clinical_resources' ),
+				'field_clinical_resource_aoe'        => array( 'name' => 'clinical_resource_aoe',         'provider' => 'physician_expertise',      'reverse' => 'field_expertise_clinical_resources' ),
+				'field_clinical_resource_conditions' => array( 'name' => 'clinical_resource_conditions',  'provider' => 'physician_conditions_cpt', 'reverse' => 'field_condition_clinical_resources' ),
+				'field_clinical_resource_treatments' => array( 'name' => 'clinical_resource_treatments',  'provider' => 'physician_treatments_cpt', 'reverse' => 'field_treatment_procedure_clinical_resources' ),
+			);
+
+		}
+
+	// Overwrite a spotlight's ontology relationships with its provider's set, and
+	// keep each ontology post's reverse Related Clinical Resources list in step. A
+	// provider of 0 clears the mirror (used when a spotlight leaves publication or
+	// stops being a spotlight). Both sides are written through update_field, like
+	// uamswp_spotlight_assert_link(): this runs outside a spotlight's own save, so
+	// ACF's save-time bidirectional pass is not available to propagate for us.
+
+		function uamswp_spotlight_sync_ontology( $cr_id, $provider_id ) {
+
+			$cr_id = (int) $cr_id;
+
+			foreach ( uamswp_spotlight_ontology_map() as $spec ) {
+
+				$target  = $provider_id ? uamswp_spotlight_to_ids( get_field( $spec['provider'], $provider_id ) ) : array();
+				$current = uamswp_spotlight_to_ids( get_field( $spec['name'], $cr_id ) );
+
+				$added   = array_values( array_diff( $target, $current ) );
+				$removed = array_values( array_diff( $current, $target ) );
+
+				if ( !$added && !$removed ) {
+
+					continue;
+
+				}
+
+				update_field( $spec['name'], $target, $cr_id );
+
+				// Add the spotlight to each newly associated ontology post
+				foreach ( $added as $ontology_id ) {
+
+					$list = uamswp_spotlight_to_ids( get_field( $spec['reverse'], $ontology_id ) );
+
+					if ( !in_array( $cr_id, $list, true ) ) {
+
+						$list[] = $cr_id;
+						update_field( $spec['reverse'], $list, $ontology_id );
+
+					}
+
+				}
+
+				// Remove it from each ontology post it no longer belongs to
+				foreach ( $removed as $ontology_id ) {
+
+					$list = uamswp_spotlight_to_ids( get_field( $spec['reverse'], $ontology_id ) );
+
+					if ( in_array( $cr_id, $list, true ) ) {
+
+						update_field( $spec['reverse'], array_values( array_diff( $list, array( $cr_id ) ) ), $ontology_id );
+
+					}
+
+				}
+
+			}
+
+		}
+
+	// Mirror the ontology into the submitted values when a spotlight is saved
+	//
+	// Runs at priority 5, before ACF writes the values at 10, so the featured
+	// provider's locations/expertise/conditions/treatments are saved as the
+	// spotlight's own and flow through ACF's save-time bidirectional pass, FacetWP
+	// indexing, and every other consumer exactly as an editor's entries would. The
+	// fields are hidden for spotlights, so their value only ever comes from here.
+
+		add_action( 'acf/save_post', 'uamswp_spotlight_reconcile_ontology', 5 );
+
+		function uamswp_spotlight_reconcile_ontology( $post_id ) {
+
+			if (
+				empty( $_POST['acf'] )
+				||
+				!is_numeric( $post_id )
+				||
+				'clinical-resource' !== get_post_type( $post_id )
+			) {
+
+				return;
+
+			}
+
+			$submitted_type = uamswp_spotlight_current_type();
+
+			$new_provider = 0;
+
+			if ( isset( $_POST['acf']['field_clinical_resource_spotlight_provider'] ) ) {
+
+				$value        = $_POST['acf']['field_clinical_resource_spotlight_provider'];
+				$value        = is_array( $value ) ? reset( $value ) : $value;
+				$new_provider = (int) $value;
+
+			}
+
+			if ( 'provider_spotlight' === $submitted_type && $new_provider ) {
+
+				// Overwrite each ontology field with the provider's current set
+				foreach ( uamswp_spotlight_ontology_map() as $cr_field => $spec ) {
+
+					$ids = uamswp_spotlight_to_ids( get_field( $spec['provider'], $new_provider ) );
+					$_POST['acf'][ $cr_field ] = array_map( 'strval', $ids );
+
+				}
+
+			} elseif ( 'provider_spotlight' === uamswp_spotlight_stored_type( $post_id ) ) {
+
+				// The resource was a spotlight and is not one now: drop the mirror
+				// rather than leave stale associations behind -- but never clobber a
+				// value the editor actually submitted (the fields are visible again
+				// once the type changes), mirroring uamswp_spotlight_reconcile_providers.
+				foreach ( uamswp_spotlight_ontology_map() as $cr_field => $spec ) {
+
+					if ( !array_key_exists( $cr_field, $_POST['acf'] ) ) {
+
+						$_POST['acf'][ $cr_field ] = array();
+
+					}
+
+				}
+
+			}
+
+		}
+
+	// Re-sync spotlights when a Condition, Treatment, or Area of Expertise is saved
+	//
+	// Those three are bidirectional with the provider, so associating a provider
+	// from the ontology side writes the provider's own field with a direct meta
+	// update that never fires the provider's save hook. (Locations are not
+	// bidirectional, so no location hook is needed.) Only spotlights whose featured
+	// provider was added to or removed from THIS ontology post can have a changed
+	// mirror, so just those are re-synced -- not the whole population.
+
+		// Ontology post type => the field on it that lists its providers (the
+		// bidirectional partner of the matching physician_* field). Empty for any
+		// other post type.
+		function uamswp_spotlight_ontology_provider_field( $post_type ) {
+
+			$fields = array(
+				'expertise' => 'field_expertise_physicians',
+				'condition' => 'field_condition_physicians',
+				'treatment' => 'field_treatment_procedure_physicians',
+			);
+
+			return isset( $fields[ $post_type ] ) ? $fields[ $post_type ] : '';
+
+		}
+
+		// Remember an ontology post's provider list across a single save, so the
+		// guard can also re-sync a provider that was just REMOVED (and is therefore
+		// absent from the saved value).
+		function uamswp_spotlight_ontology_providers_before( $post_id, $set = null ) {
+
+			static $store = array();
+
+			$post_id = (int) $post_id;
+
+			if ( null !== $set ) {
+
+				$store[ $post_id ] = $set;
+
+			}
+
+			return isset( $store[ $post_id ] ) ? $store[ $post_id ] : array();
+
+		}
+
+		// Capture the pre-save provider list at priority 5, before ACF overwrites it
+		add_action( 'acf/save_post', 'uamswp_spotlight_capture_ontology_providers', 5 );
+
+		function uamswp_spotlight_capture_ontology_providers( $post_id ) {
+
+			if ( !is_numeric( $post_id ) ) {
+
+				return;
+
+			}
+
+			$field = uamswp_spotlight_ontology_provider_field( get_post_type( $post_id ) );
+
+			if ( !$field ) {
+
+				return;
+
+			}
+
+			uamswp_spotlight_ontology_providers_before( $post_id, uamswp_spotlight_to_ids( get_field( $field, $post_id ) ) );
+
+		}
+
+		add_action( 'acf/save_post', 'uamswp_spotlight_ontology_guard', 20 );
+
+		function uamswp_spotlight_ontology_guard( $post_id ) {
+
+			if ( !is_numeric( $post_id ) ) {
+
+				return;
+
+			}
+
+			$field = uamswp_spotlight_ontology_provider_field( get_post_type( $post_id ) );
+
+			if ( !$field ) {
+
+				return;
+
+			}
+
+			// Providers on this ontology post after the save, plus any removed
+			// since before it: every provider whose mirror could have changed.
+			$after    = uamswp_spotlight_to_ids( get_field( $field, $post_id ) );
+			$before   = uamswp_spotlight_ontology_providers_before( $post_id );
+			$affected = array_values( array_unique( array_merge( $after, $before ) ) );
+
+			foreach ( $affected as $provider_id ) {
+
+				foreach ( uamswp_spotlight_posts_for_provider( $provider_id ) as $cr_id ) {
+
+					uamswp_spotlight_sync_ontology( $cr_id, $provider_id );
+
+				}
+
+			}
 
 		}

--- a/includes/class.fad-acf-functions.php
+++ b/includes/class.fad-acf-functions.php
@@ -2376,11 +2376,15 @@
 
 				}
 
-			// Slug: track the provider while drafting, then freeze at publish
+			// Slug: derive it once, then freeze so a later provider change or
+			// rename never rewrites a live URL. Freezing is tracked with a meta
+			// flag set at publish -- not the publish state itself -- because a
+			// direct publish (no prior draft save) reaches this hook already
+			// published, and gating on !$published would skip derivation entirely,
+			// leaving the permalink on a placeholder slug. Drafts keep tracking the
+			// provider until the flag is set.
 
-				$published = in_array( $post->post_status, array( 'publish', 'future', 'private' ), true );
-
-				if ( !$published ) {
+				if ( !get_post_meta( $post_id, '_uamswp_spotlight_slug_locked', true ) ) {
 
 					$slug_name = trim( str_replace( '&nbsp;', ' ', $names['medium_no_prefix'] ) );
 
@@ -2391,6 +2395,13 @@
 						if ( $new_slug && $post->post_name !== $new_slug ) {
 
 							$update['post_name'] = $new_slug;
+
+						}
+
+						// Once published, freeze: the permalink is now live.
+						if ( in_array( $post->post_status, array( 'publish', 'future', 'private' ), true ) ) {
+
+							update_post_meta( $post_id, '_uamswp_spotlight_slug_locked', '1' );
 
 						}
 

--- a/includes/class.fad-custom-post.php
+++ b/includes/class.fad-custom-post.php
@@ -5162,10 +5162,9 @@
 				$data['clinical_resource_spotlight_provider']['title'] = get_field( 'physician_full_name', $spotlight_provider );
 				$data['clinical_resource_spotlight_provider']['slug'] = get_post_field( 'post_name', $spotlight_provider );
 
-				// The introduction falls back to generated prose on the front
-				// end rather than being stored, so export what a reader sees
-				$spotlight_intro = get_field( 'clinical_resource_spotlight_intro', $postId );
-				$data['clinical_resource_spotlight_intro'] = $spotlight_intro ? $spotlight_intro : uamswp_spotlight_default_intro( $spotlight_provider );
+				// The introduction is always generated from the provider (the
+				// manual field was removed), so export what a reader sees.
+				$data['clinical_resource_spotlight_intro'] = uamswp_spotlight_default_intro( $spotlight_provider );
 
 				$data['clinical_resource_spotlight_image_wide'] = get_field( 'clinical_resource_spotlight_image_wide', $postId );
 				$data['clinical_resource_spotlight_phone'] = get_field( 'clinical_resource_spotlight_phone', $postId );

--- a/includes/class.fad-helper-functions.php
+++ b/includes/class.fad-helper-functions.php
@@ -415,7 +415,7 @@ if ( !function_exists('uamswp_provider_names') ) {
 
 	/**
 	 * @param  int  $provider_id  Provider post ID.
-	 * @return array short, medium, full, short_possessive, sort, sort_param, and _attr variants.
+	 * @return array short, medium, medium_no_prefix, full, short_possessive, sort, sort_param, and _attr variants.
 	 */
 	function uamswp_provider_names( $provider_id ) {
 
@@ -424,6 +424,8 @@ if ( !function_exists('uamswp_provider_names') ) {
 			'full_attr'             => '',
 			'medium'                => '',
 			'medium_attr'           => '',
+			'medium_no_prefix'      => '',
+			'medium_no_prefix_attr' => '',
 			'short'                 => '',
 			'short_attr'            => '',
 			'short_possessive'      => '',
@@ -532,6 +534,12 @@ if ( !function_exists('uamswp_provider_names') ) {
 
 				$medium_name = ($prefix ? $prefix .' ' : '') . $first_name .' ' . ($middle_name ? $middle_name . ' ' : '') . $last_name;
 
+			// Medium name without the "Dr." prefix or any degrees (e.g.,
+			// "Leonard H. McCoy"). Useful where the prefix and credentials get
+			// in the way -- e.g. building a clean URL slug.
+
+				$medium_no_prefix_name = trim( $first_name .' ' . ($middle_name ? $middle_name . ' ' : '') . $last_name );
+
 			// Short name (e.g., "Dr. McCoy")
 
 				$short_name = $prefix ? $prefix .'&nbsp;' .$last_name : $first_name .' ' . ($middle_name ? $middle_name . ' ' : '') . $last_name . ($pedigree ? '&nbsp;' . $pedigree : '');
@@ -562,6 +570,8 @@ if ( !function_exists('uamswp_provider_names') ) {
 			'full_attr'             => $full_name ? uamswp_attr_conversion($full_name) : '',
 			'medium'                => $medium_name,
 			'medium_attr'           => $medium_name ? uamswp_attr_conversion($medium_name) : '',
+			'medium_no_prefix'      => $medium_no_prefix_name,
+			'medium_no_prefix_attr' => $medium_no_prefix_name ? uamswp_attr_conversion($medium_no_prefix_name) : '',
 			'short'                 => $short_name,
 			'short_attr'            => $short_name ? uamswp_attr_conversion($short_name) : '',
 			'short_possessive'      => $short_name_possessive,

--- a/includes/class.fad-helper-functions.php
+++ b/includes/class.fad-helper-functions.php
@@ -735,7 +735,9 @@ if ( !function_exists('uamswp_spotlight_default_excerpt') ) {
 		}
 
 		$names = uamswp_provider_names( $provider_id );
-		$title = uamswp_provider_occupation_title( $provider_id );
+
+		// Lowercase the clinical title for the generated prose (e.g. "optometrist")
+		$title = mb_strtolower( uamswp_provider_occupation_title( $provider_id ) );
 
 		// The name variants carry a non-breaking space; the excerpt is plain text
 		$name = $names['medium_attr'];
@@ -803,7 +805,9 @@ if ( !function_exists('uamswp_spotlight_default_intro') ) {
 		}
 
 		$names    = uamswp_provider_names( $provider_id );
-		$title    = uamswp_provider_occupation_title( $provider_id );
+
+		// Lowercase the clinical title for the generated prose (e.g. "an optometrist")
+		$title    = mb_strtolower( uamswp_provider_occupation_title( $provider_id ) );
 		$pronouns = uamswp_provider_pronouns( $provider_id );
 
 		// Guard the trimmed value: the medium variant is built by concatenation,

--- a/includes/class.fad-helper-functions.php
+++ b/includes/class.fad-helper-functions.php
@@ -951,15 +951,16 @@ if ( !function_exists('uamswp_spotlight_appointment_cta') ) {
 			$referral = $refer_req ? 'Appointments for new patients are by referral only. ' : '';
 
 			$phone      = get_field( 'clinical_resource_spotlight_phone' );
-			$phone_href = $phone ? preg_replace( '/[^0-9+]/', '', $phone ) : '';
+			// Dashed format for both the tel: href and the visible text (e.g. 501-686-8000)
+			$phone_dash = $phone ? format_phone_dash( $phone ) : '';
 
-			if ( $phone && $phone_href ) {
+			if ( $phone && $phone_dash ) {
 
 				$tel_link = sprintf(
 					'<a href="tel:%1$s" class="no-break" data-itemtitle="Call to schedule with %2$s">%3$s</a>',
-					esc_attr( $phone_href ),
+					esc_attr( $phone_dash ),
 					esc_attr( $medium_name_attr ),
-					esc_html( $phone )
+					esc_html( $phone_dash )
 				);
 
 				$cta_body = $referral . sprintf(

--- a/templates/single-clinical-resource.php
+++ b/templates/single-clinical-resource.php
@@ -654,12 +654,9 @@ function uamswp_resource_provider_spotlight() {
     $short_name       = uamswp_provider_name_html( $names['short'] );
     $short_possessive = uamswp_provider_name_html( $names['short_possessive'] );
 
-    // Introduction, falling back to generated prose
-    $intro = get_field('clinical_resource_spotlight_intro');
-
-    if ( !$intro ) {
-        $intro = uamswp_spotlight_default_intro( $provider_id );
-    }
+    // Introduction: always generated from the provider. The manual field was
+    // removed, so any value left in postmeta from before that is ignored.
+    $intro = uamswp_spotlight_default_intro( $provider_id );
 
     if ( $intro ) {
         echo '<h2 class="sr-only">Description</h2>';


### PR DESCRIPTION
Follow-up to #803 (merged), making a Provider Spotlight fully provider-driven: everything that can be pulled from the featured provider is now derived or mirrored, and the manual inputs that would drift from it are hidden. This is the reconciliation surface the Statamic migration tracks in [`UAMS-Web/uams-statamic#1428`](https://github.com/UAMS-Web/uams-statamic/issues/1428).

The whole branch was put through an adversarial review before this PR; the four confirmed findings are fixed in the last commits (see `## Verification`).

## Approach

A spotlight editor should pick a provider and write the Q&A — nothing else. Everything else follows from the provider, so hand-entering it only invites drift, duplicate SEO titles, and confusing same-name search results.

- **Title and slug** are derived from the provider. Title is `"Get to Know " + physician_full_name` (e.g. "Get to Know W. Ryan Wood, O.D."), refreshed every save so a rename self-corrects. Slug is `sanitize_title("Get to Know " + <name, no "Dr." prefix, no degrees>)` (e.g. `get-to-know-w-ryan-wood`), derived once and frozen after first publish so a live URL is never rewritten. A new `medium_no_prefix` name variant on `uamswp_provider_names()` supplies the degree-free slug source.
- **Introduction** is always generated from the provider; the manual field is removed.
- **Short Description and Short Title** — the excerpt is always regenerated from the provider on save (the input is hidden, so it stays provider-driven), and a spotlight's card/list title comes from the derived post title, so both inputs are hidden. That empties the General Details tab, so the tab is hidden too (the ASP Filter it also holds is a hidden system field, unaffected).
- **Ontology** — Locations, Areas of Expertise, Conditions, and Treatments are an exact copy (overwrite, not union) of the featured provider's, kept in sync continuously and hidden from the editor. Each clinical-resource field is bidirectional with its ontology post, so the mirror rides the same machinery as the existing provider mirror and the spotlight shows up in each location/expertise/condition/treatment post's own Related Clinical Resources. Kept current from every direction: the spotlight's own save (priority-5 `$_POST` injection), the provider's save, and a Condition/Treatment/Expertise save (only the affected providers' spotlights re-sync, using the pre-save provider list to catch removals as well as additions). The four fields and their four tabs — plus the Related Providers tab — are hidden for spotlights. Related Clinical Resources is intentionally left editor-managed.
- **Cosmetic** — the generated excerpt and intro lowercase the clinical title ("… an optometrist at UAMS Health") and the phrase "provider spotlight", and the appointment CTA phone renders dashed (`501-686-8000`) via the theme's `format_phone_dash()`.

## Commits

- `b9042d41` feat(providers): add `medium_no_prefix` name variant
- `81fd6bcb` feat(spotlight): derive the post title and slug from the featured provider
- `d10a6c18` feat(spotlight): hide auto-generated Short Description; remove Introduction input
- `d0a3a99e` style(spotlight): lowercase the clinical title in the generated excerpt and intro
- `58c75fec` feat(spotlight): format the CTA appointment phone as dashes
- `00c3da80` feat(spotlight): hide the ontology relationship fields and their tabs
- `596237e9` feat(spotlight): mirror the provider's ontology onto the spotlight
- `7bc1b8b3` fix(spotlight): derive the slug on a direct publish, not only from a draft
- `4b3ad965` fix(spotlight): always generate the intro, ignoring removed-field postmeta
- `85c32c3f` feat(spotlight): hide the Short Title input and the General Details tab
- `5b055b88` style(spotlight): lowercase "provider spotlight" in the generated excerpt
- `a553a2c0` fix(spotlight): always regenerate the Short Description from the provider

## Files

- **edit** [`includes/class.fad-acf-functions.php`](https://github.com/UAMS-Web/UAMSWP-Find-a-Doc/blob/Provider-Spotlight/includes/class.fad-acf-functions.php) — title/slug derivation (`uamswp_spotlight_sync_title`) and the ontology mirror (map, `sync_ontology`, the CR-save/provider-save/ontology-save/status/delete hooks).
- **edit** [`includes/class.fad-helper-functions.php`](https://github.com/UAMS-Web/UAMSWP-Find-a-Doc/blob/Provider-Spotlight/includes/class.fad-helper-functions.php) — `medium_no_prefix` variant; lowercase the clinical title in the generated excerpt and intro; dashed CTA phone.
- **edit** [`assets/json/acf-json/group_uamswp_clinical_resources.json`](https://github.com/UAMS-Web/UAMSWP-Find-a-Doc/blob/Provider-Spotlight/assets/json/acf-json/group_uamswp_clinical_resources.json) — hide Short Title, Short Description, and the four ontology fields plus the General Details tab and the four ontology tabs for spotlights; remove the Introduction field.
- **edit** [`templates/single-clinical-resource.php`](https://github.com/UAMS-Web/UAMSWP-Find-a-Doc/blob/Provider-Spotlight/templates/single-clinical-resource.php) — always generate the intro on the front end.
- **edit** [`includes/class.fad-custom-post.php`](https://github.com/UAMS-Web/UAMSWP-Find-a-Doc/blob/Provider-Spotlight/includes/class.fad-custom-post.php) — always generate the intro in the `resource_meta` REST export.

## Verification

Exercised against real data on a local WordPress install (spotlight #5357, provider #500):

- **Ontology mirror** — from an empty spotlight, `sync_ontology` set all four fields to exactly the provider's sets, added the spotlight to all four ontology posts' reverse Related Clinical Resources lists, and a second run was a no-op. ✓
- **Slug fix** — the test spotlight had a placeholder `Foo`/`foo` title/slug (the exact direct-publish case). After sync: `Get to Know Ludovico F. Setalla Jr., M.D., D.O., Ph.D.` / `get-to-know-ludovico-f-setalla`, locked, and unchanged on a second run. ✓
- **Retargeted guard** — saving a Condition correctly resolves its providers (including the removed ones via the captured pre-save list) and re-syncs only their spotlights. ✓
- **Adversarial review** — five risk-lens reviewers over the diff, each finding refuted against the code; four confirmed and fixed: slug-on-direct-publish (`7bc1b8b3`), stale-intro-postmeta override (`4b3ad965`), ontology-guard provider targeting, and preserving editor-submitted ontology values when a spotlight is converted to another type (both in `596237e9`).

## Companion PRs

- [`UAMS-Web/uams-2020#562`](https://github.com/UAMS-Web/uams-2020/pull/562) — the reusable theme utilities the spotlight styles itself with (`content-rule` / `.rule-top-lg`, `.d-flow-root`, the first-child aligned-figure heading fix), plus `text-wrap: pretty` on `.cta-bar-1 p`. File-disjoint from this PR; no merge ordering required.

## Test plan

- [x] `php -l` clean on every changed PHP file; ACF JSON validates and still parses to its full field set.
- [x] Ontology mirror, slug derivation, and the retargeted guard verified against live data (see `## Verification`).
- [x] Adversarial review complete; all four confirmed findings fixed and re-verified.
- [ ] Staging: create a spotlight and Publish directly (no draft save) — confirm the permalink is `get-to-know-{name}`, not a placeholder.
- [ ] Staging: confirm the Locations, Areas of Expertise, Conditions, and Treatments tabs are hidden on a spotlight and visible on every other resource type, and that a non-spotlight resource's own relationships are untouched by a save.
- [ ] Staging: add/remove a location on the featured provider's profile and confirm the spotlight gains/loses it; do the same from a Condition post's provider list.
- [ ] Staging: re-index FacetWP so the spotlight appears under the mirrored `resource_provider` / location / condition / treatment facets.

## Out of scope

- **Related Clinical Resources** is deliberately not mirrored or hidden — it stays editor-managed.
- **FacetWP re-index** is a runtime/DB step (facet config lives in `wp_options`), noted in the test plan rather than carried in this diff.

