### PR TITLE
Hide the remaining Provider Spotlight editor inputs and always regenerate its Short Description

### DIFF
--- a/assets/json/acf-json/group_uamswp_clinical_resources.json
+++ b/assets/json/acf-json/group_uamswp_clinical_resources.json
@@ -9,7 +9,15 @@
 			"type": "tab",
 			"instructions": "",
 			"required": 0,
-			"conditional_logic": 0,
+			"conditional_logic": [
+				[
+					{
+						"field": "field_clinical_resource_type",
+						"operator": "!=",
+						"value": "provider_spotlight"
+					}
+				]
+			],
 			"wrapper": {
 				"width": "",
 				"class": "",
@@ -25,7 +33,15 @@
 			"type": "text",
 			"instructions": "Enter a value here to set a shorter title to use where this resource appears in cards and lists. Leave it blank to use the full title.</p><p class='description' style='margin-top: 0.5em;'>The full title is always used for the page heading itself.",
 			"required": 0,
-			"conditional_logic": 0,
+			"conditional_logic": [
+				[
+					{
+						"field": "field_clinical_resource_type",
+						"operator": "!=",
+						"value": "provider_spotlight"
+					}
+				]
+			],
 			"wrapper": {
 				"width": "",
 				"class": "",

--- a/includes/class.fad-acf-functions.php
+++ b/includes/class.fad-acf-functions.php
@@ -2504,19 +2504,16 @@
 
 				}
 
-			// Short description, when the editor left it blank
+			// Short description: always regenerated from the provider. The input is
+			// hidden for spotlights, so it is fully provider-driven -- overwriting
+			// also clears any stale value and picks up changes to the generated
+			// prose. custom_excerpt_acf() copies it to post_excerpt at priority 50.
 
-				$excerpt = get_field( 'clinical_resource_excerpt', $post_id );
+				$generated = uamswp_spotlight_default_excerpt( $provider_id );
 
-				if ( '' === trim( (string) $excerpt ) ) {
+				if ( $generated ) {
 
-					$generated = uamswp_spotlight_default_excerpt( $provider_id );
-
-					if ( $generated ) {
-
-						update_field( 'clinical_resource_excerpt', $generated, $post_id );
-
-					}
+					update_field( 'clinical_resource_excerpt', $generated, $post_id );
 
 				}
 

--- a/includes/class.fad-helper-functions.php
+++ b/includes/class.fad-helper-functions.php
@@ -753,7 +753,7 @@ if ( !function_exists('uamswp_spotlight_default_excerpt') ) {
 		if ( $title ) {
 
 			$excerpt = sprintf(
-				'Meet %1$s, %2$s at UAMS Health, in this Provider Spotlight Q&A.',
+				'Meet %1$s, %2$s at UAMS Health, in this provider spotlight Q&A.',
 				$name,
 				$title
 			);
@@ -761,7 +761,7 @@ if ( !function_exists('uamswp_spotlight_default_excerpt') ) {
 		} else {
 
 			$excerpt = sprintf(
-				'Meet %1$s of UAMS Health in this Provider Spotlight Q&A.',
+				'Meet %1$s of UAMS Health in this provider spotlight Q&A.',
 				$name
 			);
 


### PR DESCRIPTION
Follow-up to #805 (merged), finishing the "an editor only picks a provider and writes the Q&A" surface for a Provider Spotlight and keeping the auto-generated Short Description in step with the provider.

## Commits

- `85c32c3f` feat(spotlight): hide the Short Title input and the General Details tab
- `5b055b88` style(spotlight): lowercase "provider spotlight" in the generated excerpt
- `a553a2c0` fix(spotlight): always regenerate the Short Description from the provider

## Changes

- **Hide the last General-tab inputs.** Short Description, Featured Image, and Square Image were already hidden for spotlights, leaving Short Title as the only editor-visible field in the General Details tab. Hide it — which empties the tab — so hide the tab too. The ASP Filter the tab also holds is a hidden system field, unaffected; and a spotlight's card/list title falls back to the derived post title, so the Short Title override is not needed there.
- **Always regenerate the Short Description.** The excerpt was generated only when the field was blank, so a spotlight that already had one — a manual value, or one generated before the prose changed — kept the stale text with no way to refresh it now that the input is hidden. Regenerate it from the provider on every save instead (`custom_excerpt_acf()` still copies it to `post_excerpt` at priority 50), matching the always-generated intro.
- **Lowercase "provider spotlight"** in the generated excerpt prose ("… in this provider spotlight Q&A."), matching the mid-sentence casing of the rest of the generated text.

## Files

- **edit** [`assets/json/acf-json/group_uamswp_clinical_resources.json`](https://github.com/UAMS-Web/UAMSWP-Find-a-Doc/blob/Provider-Spotlight/assets/json/acf-json/group_uamswp_clinical_resources.json) — `conditional_logic` hiding Short Title and the General Details tab for spotlights.
- **edit** [`includes/class.fad-helper-functions.php`](https://github.com/UAMS-Web/UAMSWP-Find-a-Doc/blob/Provider-Spotlight/includes/class.fad-helper-functions.php) — lowercase "provider spotlight" in the generated excerpt.
- **edit** [`includes/class.fad-acf-functions.php`](https://github.com/UAMS-Web/UAMSWP-Find-a-Doc/blob/Provider-Spotlight/includes/class.fad-acf-functions.php) — regenerate the excerpt for spotlights on every save rather than only when blank.

## Verification

- Generated excerpt confirmed against live data: "Meet Dr. Ludovico F. Setalla, orthopaedic spine surgeon at UAMS Health, in this provider spotlight Q&A." — lowercase clinical title and "provider spotlight". ✓
- JSON validates; the General Details tab and all four of its editor fields read hidden-for-spotlight. ✓
- `php -l` clean on both changed PHP files.

## Test plan

- [x] JSON valid; General Details tab and Short Title hidden for spotlights.
- [x] Excerpt generator output verified (lowercase clinical title and "provider spotlight").
- [ ] Staging: edit a spotlight and Update — confirm the General Details tab is gone and the Short Description refreshes (a prior manual excerpt is replaced by the generated one).
- [ ] Staging: confirm non-spotlight resource types still show the General Details tab and the Short Title input.
